### PR TITLE
Plan for creating venv in new worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ clean_branch = "ask"
 enabled = true  # Enable/disable the feature
 patterns = [".env", ".env.*", ".env.local", ".env.*.local"]  # Files to copy
 exclude_patterns = [".env.example", ".env.sample"]  # Files to exclude
+
+# Python project settings
+# Automatically detect Python projects and resolve .venv directory issues
+[python]
+auto_detect = true  # Enable automatic Python project detection (default: true)
+exclude_venv = true  # Automatically exclude .venv directory (default: true)
+suggest_venv_recreate = true  # Show suggestions for recreating venv (default: true)
+exclude_patterns = [".venv", ".venv/*", "__pycache__", "*.pyc", "*.pyo", ".pytest_cache"]  # Python-specific exclusion patterns
 ```
 
 ## 📖 Command reference

--- a/README_JA.md
+++ b/README_JA.md
@@ -112,6 +112,14 @@ clean_branch = "ask"
 enabled = true  # 機能の有効/無効
 patterns = [".env", ".env.*", ".env.local", ".env.*.local"]  # コピー対象
 exclude_patterns = [".env.example", ".env.sample"]  # 除外対象
+
+# Python プロジェクト用の設定
+# Python プロジェクトを自動検出し、.venv ディレクトリの問題を解決します
+[python]
+auto_detect = true  # Pythonプロジェクトの自動検出を有効にする（デフォルト: true）
+exclude_venv = true  # .venvディレクトリを自動除外する（デフォルト: true）
+suggest_venv_recreate = true  # venv再作成の提案を表示する（デフォルト: true）
+exclude_patterns = [".venv", ".venv/*", "__pycache__", "*.pyc", "*.pyo", ".pytest_cache"]  # Python固有の除外パターン
 ```
 
 ## 📖 コマンドリファレンス

--- a/python-venv-fix-summary.md
+++ b/python-venv-fix-summary.md
@@ -1,0 +1,123 @@
+# Python プロジェクトでの .venv 問題解決 - 実装完了
+
+## 問題の概要
+
+パイソンで書かれたアプリケーションを管理しているリポジトリで `gwm add` を実行した場合、`.venv` のパスが大元のワークツリーを参照してしまうため、新しく作成したワークツリー内に `.venv` を正常に作成することができない問題がありました。
+
+## 解決策の実装
+
+### 1. Pythonプロジェクト自動検出機能
+
+新しく `isPythonProject()` 関数を実装し、以下のファイルの存在を確認してPythonプロジェクトを自動検出します：
+
+- `pyproject.toml`
+- `poetry.lock`
+- `requirements.txt`
+- `requirements-dev.txt`
+- `setup.py`
+- `setup.cfg`
+- `Pipfile`
+- `Pipfile.lock`
+- `conda.yml`
+- `environment.yml`
+
+### 2. 設定ファイルの拡張
+
+`~/.config/gwm/config.toml` に新しい Python 関連設定を追加しました：
+
+```toml
+[python]
+auto_detect = true  # Pythonプロジェクトの自動検出を有効にする（デフォルト: true）
+exclude_venv = true  # .venvディレクトリを自動除外する（デフォルト: true）
+suggest_venv_recreate = true  # venv再作成の提案を表示する（デフォルト: true）
+exclude_patterns = [".venv", ".venv/*", "__pycache__", "*.pyc", "*.pyo", ".pytest_cache"]  # Python固有の除外パターン
+```
+
+### 3. .venv 自動除外機能
+
+Pythonプロジェクトが検出された場合、以下の処理が自動実行されます：
+
+1. **`.venv` ディレクトリの自動除外**: gitignoreされたファイルのコピー処理で `.venv` ディレクトリを自動的に除外
+2. **Python固有ファイルの除外**: `__pycache__`、`*.pyc`、`.pytest_cache` などのPython固有の一時ファイルも除外
+
+### 4. venv 再作成ガイダンス
+
+新しいワークツリー作成時に、Pythonプロジェクトが検出された場合は適切なvenv再作成コマンドを提案：
+
+- **Poetry プロジェクト**: `poetry install`
+- **Pipenv プロジェクト**: `pipenv install`
+- **requirements.txt**: `python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`
+- **その他**: `python -m venv .venv`
+
+### 5. 設定のカスタマイズ
+
+ユーザーは設定ファイルで以下をカスタマイズ可能：
+
+- Python自動検出のオン/オフ
+- .venv除外のオン/オフ
+- venv再作成提案のオン/オフ
+- カスタム除外パターンの追加
+
+## 使用方法
+
+### 基本的な使用方法
+
+1. **設定ファイルの作成**（オプション）:
+   ```bash
+   mkdir -p ~/.config/gwm
+   cat > ~/.config/gwm/config.toml << 'EOF'
+   [python]
+   auto_detect = true
+   exclude_venv = true
+   suggest_venv_recreate = true
+   EOF
+   ```
+
+2. **ワークツリーの作成**:
+   ```bash
+   # Pythonプロジェクトで実行
+   gwm add feature/new-feature
+   ```
+
+3. **venv再作成**（新しいワークツリーで）:
+   ```bash
+   cd path/to/new/worktree
+   poetry install  # または表示された適切なコマンド
+   ```
+
+### 期待される結果
+
+- ✅ `.venv` ディレクトリがコピーされなくなる
+- ✅ 新しいワークツリーで独立したvenvを作成可能
+- ✅ 適切なvenv再作成コマンドが提案される
+- ✅ Python固有の一時ファイルも除外される
+
+## 従来の手動作業との比較
+
+### 従来の解決方法
+1. 大元のブランチにあるvenvを削除する
+2. 新規ワークツリーでvenvの参照先設定を変更する
+3. 新規ワークツリーでvenvを作成するコマンドを実行する
+
+### 新しい自動化された方法
+1. `gwm add` を実行するだけ
+2. 表示される提案に従ってvenvを再作成
+
+## 技術的詳細
+
+### 実装されたファイル
+
+- `src/utils/git.ts`: `isPythonProject()` 関数、`getIgnoredFiles()` 更新
+- `src/config.ts`: Python設定の追加
+- `src/hooks/useWorktree.ts`: venv再作成提案の追加
+- `test/python-detection.test.ts`: テストケースの追加
+
+### 互換性
+
+- 既存の設定ファイルとの完全な後方互換性
+- デフォルト設定でPython対応が有効
+- 非Pythonプロジェクトでは従来通りの動作
+
+## まとめ
+
+この実装により、Pythonプロジェクトでの `gwm add` 実行時に `.venv` の問題が自動的に解決され、開発者の手動作業が大幅に削減されます。設定も柔軟にカスタマイズ可能で、様々なPythonプロジェクト構成に対応しています。

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,7 +55,14 @@ const DEFAULT_CONFIG: Config = {
     auto_detect: true,
     exclude_venv: true,
     suggest_venv_recreate: true,
-    exclude_patterns: ['.venv', '.venv/*', '__pycache__', '*.pyc', '*.pyo', '.pytest_cache'],
+    exclude_patterns: [
+      '.venv',
+      '.venv/*',
+      '__pycache__',
+      '*.pyc',
+      '*.pyo',
+      '.pytest_cache',
+    ],
   },
 };
 
@@ -116,10 +123,7 @@ export function loadConfig(): Config {
 
         // python設定の読み込み
         let pythonConfig = DEFAULT_CONFIG.python;
-        if (
-          parsed.python &&
-          typeof parsed.python === 'object'
-        ) {
+        if (parsed.python && typeof parsed.python === 'object') {
           const py = parsed.python as Record<string, unknown>;
           pythonConfig = {
             auto_detect:

--- a/src/hooks/useWorktree.ts
+++ b/src/hooks/useWorktree.ts
@@ -101,18 +101,29 @@ export function useWorktree({
         }
 
         // Pythonプロジェクトの場合、venv再作成の提案を表示
-        if (config.python?.auto_detect && config.python?.suggest_venv_recreate && isPythonProject(worktreePath)) {
-          actions.push('💡 Python project detected! Consider recreating virtual environment:');
-          
+        if (
+          config.python?.auto_detect &&
+          config.python?.suggest_venv_recreate &&
+          isPythonProject(worktreePath)
+        ) {
+          actions.push(
+            '💡 Python project detected! Consider recreating virtual environment:'
+          );
+
           // プロジェクトファイルに基づいて適切なコマンドを提案
           const mainWorktreePath = getMainWorktreePath();
           if (mainWorktreePath) {
-            if (existsSync(join(mainWorktreePath, 'pyproject.toml')) || existsSync(join(mainWorktreePath, 'poetry.lock'))) {
+            if (
+              existsSync(join(mainWorktreePath, 'pyproject.toml')) ||
+              existsSync(join(mainWorktreePath, 'poetry.lock'))
+            ) {
               actions.push('   • poetry install');
             } else if (existsSync(join(mainWorktreePath, 'Pipfile'))) {
               actions.push('   • pipenv install');
             } else if (existsSync(join(mainWorktreePath, 'requirements.txt'))) {
-              actions.push('   • python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt');
+              actions.push(
+                '   • python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt'
+              );
             } else {
               actions.push('   • python -m venv .venv');
             }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -581,10 +581,10 @@ export function isPythonProject(projectPath: string): boolean {
     'Pipfile',
     'Pipfile.lock',
     'conda.yml',
-    'environment.yml'
+    'environment.yml',
   ];
 
-  return pythonFiles.some(file => existsSync(join(projectPath, file)));
+  return pythonFiles.some((file) => existsSync(join(projectPath, file)));
 }
 
 /**
@@ -600,15 +600,15 @@ export function getIgnoredFiles(
 ): string[] {
   const matchedFiles: string[] = [];
   const config = loadConfig();
-  
+
   // Pythonプロジェクトの場合、設定に基づいて自動除外
   const effectiveExcludePatterns = [...(excludePatterns || [])];
-  
+
   if (config.python?.auto_detect && isPythonProject(workdir)) {
     if (config.python.exclude_venv) {
       effectiveExcludePatterns.push('.venv', '.venv/*', '.venv/**/*');
     }
-    
+
     // Python固有の除外パターンを追加
     if (config.python.exclude_patterns) {
       effectiveExcludePatterns.push(...config.python.exclude_patterns);


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of Python projects and exclusion of Python-specific directories and files (such as `.venv`, `__pycache__`, and bytecode files) when managing worktrees.
  * Introduced configuration options to control Python project detection, exclusion patterns, and suggestions for recreating virtual environments in new worktrees.
  * When a Python project is detected, users will receive recommended commands to recreate the virtual environment in the new worktree.

* **Documentation**
  * Updated documentation to describe new Python project configuration options and behavior for managing virtual environments and related files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->